### PR TITLE
Add LIMA dropout

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -541,6 +541,9 @@ def _add_regularization_args(parser):
                        help='Post attention dropout probability.')
     group.add_argument('--hidden_dropout', type=float, default=0.1,
                        help='Dropout probability for hidden state transformer.')
+    # see "LIMA: Less Is More for Alignment", Zhou et al 2023, https://arxiv.org/abs/2305.11206
+    group.add_argument('--lima_dropout', action='store_true',
+                       help='Linearly raise the hidden_dropout probability from 0.0 at the first layer to the full hidden_dropout value at the last layer.')
     group.add_argument('--weight_decay', type=float, default=0.01,
                        help='Weight decay coefficient for L2 regularization.')
     group.add_argument('--start_weight_decay', type=float,

--- a/megatron/model/falcon_model.py
+++ b/megatron/model/falcon_model.py
@@ -34,7 +34,7 @@ class FalconModel(GPTModel):
             warnings.warn("Falcon should not use bias_gelu_fusion")
         if args.bias_dropout_fusion:
             warnings.warn("Falcon should not use bias_dropout_fusion")
-        if args.hidden_dropout > 0.0:
+        if args.hidden_dropout > 0.0 and not args.lima_dropout:
             warnings.warn("Falcon should not use dropout")
         super().__init__(num_tokentypes=num_tokentypes, parallel_output=parallel_output,
                          pre_process=pre_process, post_process=post_process,

--- a/megatron/model/language_model.py
+++ b/megatron/model/language_model.py
@@ -388,7 +388,7 @@ class TransformerLanguageModel(MegatronModule):
             self.embedding = Embedding(self.hidden_size,
                                        args.padded_vocab_size,
                                        args.max_position_embeddings,
-                                       args.hidden_dropout,
+                                       args.hidden_dropout if not args.lima_dropout else 0.0,
                                        self.init_method,
                                        self.num_tokentypes)
             self._embedding_key = 'embedding'

--- a/megatron/model/llama_model.py
+++ b/megatron/model/llama_model.py
@@ -34,7 +34,7 @@ class LlamaModel(GPTModel):
             warnings.warn("Llama is not intended to use bias_gelu_fusion")
         if args.bias_dropout_fusion:
             warnings.warn("Llama does is not intended to use bias_dropout_fusion")
-        if args.hidden_dropout > 0.0:
+        if args.hidden_dropout > 0.0 and not args.lima_dropout:
             warnings.warn( "Llama is not intended to use dropout")
         if args.attention_dropout > 0.0:
             warnings.warn( "Llama is not intended to use dropout")

--- a/tools/checkpoint_loader_megatron.py
+++ b/tools/checkpoint_loader_megatron.py
@@ -178,6 +178,7 @@ def _load_checkpoint(queue, args):
     md.parallel_layernorm = margs.parallel_layernorm
     md.use_flash_attn = margs.use_flash_attn
     md.hidden_dropout = margs.hidden_dropout
+    md.lima_dropout = margs.lima_dropout
     md.use_bias = margs.use_bias
     md.use_rms_norm = margs.use_rms_norm
     md.ffn_hidden_size = margs.ffn_hidden_size

--- a/tools/checkpoint_saver_megatron.py
+++ b/tools/checkpoint_saver_megatron.py
@@ -124,6 +124,8 @@ def save_checkpoint(queue, args):
         sys.argv += ["--use_rms_norm"]
     if not md.tie_embed_logits:
         sys.argv += ["--no_tie_embed_logits"]
+    if md.lima_dropout:
+        sys.argv += ["--lima_dropout"]
 
     if md.make_vocab_size_divisible_by is not None:
         sys.argv.extend(['--make_vocab_size_divisible_by', str(md.make_vocab_size_divisible_by)])


### PR DESCRIPTION
When `--lima_dropout` is specified use a layer dependent dropout probability, starting at p_d=0.0 at the bottom layer and linearly raising the rate to the value specified by `--hidden_dropout` at the last layer.

See: "LIMA: Less Is More for Alignment", Zhou et al 2023, https://arxiv.org/abs/2305.11206