### PR TITLE
more appropriate --chunk_size for tools/preprocess_data.py

### DIFF
--- a/docs/guide/getting_started.md
+++ b/docs/guide/getting_started.md
@@ -99,7 +99,7 @@ python tools/preprocess_data.py --input=/path/to/raw.jsonl \
 	--output_prefix=/path/to/tokenized/starcoder \
 	--tokenizer_type=SentencePieceTokenizer \
 	--vocab_file=/path/to/tokenizer.model \
-	--chunk_size=1024 \
+	--chunk_size=32 \
 	--workers=16 \
 	--no_new_tokens
 ```


### PR DESCRIPTION
In the original repository, --chunk_size is used for multiprocessing and is set to 32 (see [here](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/preprocess_data.py#L126)). However, in the guideline, --chunk_size is set to 1024. Additionally, a subsequent note states that the experiment sequence length is also 1024. This could be misleading.