### PR TITLE
Improve NaN detection by checking `grad_norm`

### DIFF
--- a/megatron/training.py
+++ b/megatron/training.py
@@ -93,7 +93,7 @@ def pretrain(args,
     # This will be closer to what scheduler will see (outside of
     # image ... launches.
     global _TRAIN_START_TIME
-    start_time_tensor = torch.cuda.DoubleTensor([_TRAIN_START_TIME])
+    start_time_tensor = torch.tensor([_TRAIN_START_TIME], dtype=torch.float64, device='cuda')
     torch.distributed.all_reduce(start_time_tensor,
                                  op=torch.distributed.ReduceOp.MIN)
     _TRAIN_START_TIME = start_time_tensor.item()


### PR DESCRIPTION
When training with `--bf16` without `grad_scaler` the current version did not properly detect `NaN`s in gradients. The [code checking for NaNs](https://github.com/epfLLM/Megatron-LLM/blob/5ac93aac1b64cee7ebb0503eb36b386830348f31/megatron/optimizer/optimizer.py#L417-L431) was only executed when grad_scaler `is not None`. This PR adds a `isfinite()` check to the `grad_norm` returned by `clip_grad_norm()`. Gradient clipping is enabled by default and this adds almost no additional computation.
(Limitation: NaN detection still doesn't work when both gradient clipping and no grad_scaler is used).

Example log output of graceful NaN handling during a training run:
```
 iteration     3633/    8000 | consumed samples:       232512 | elapsed time per iteration (ms): 6956.6 | learning rate: 6.245E-06 | global batch size:    64 | loss scale: 1.0 | grad norm: 0.794 | number of skipped iterations:   0 | number of nan iterations:   0 |
***WARNING*** Bad grad_norm detected (grad_norm=nan)                                                                                                                                                         
 iteration     3634/    8000 | consumed samples:       232576 | elapsed time per iteration (ms): 8295.0 | learning rate: 6.245E-06 | global batch size:    64 | loss scale: 1.0 | number of skipped iterations:   1 | number of nan iterations:   0 | 
 iteration     3635/    8000 | consumed samples:       232640 | elapsed time per iteration (ms): 6976.1 | learning rate: 6.243E-06 | global batch size:    64 | loss scale: 1.0 | grad norm: 0.750 | number of skipped iterations:   0 | number of nan iterations:   0 | 
```

resolves: #33

(the change in training.py removes a deprecation warning)