### PR TITLE
llama2 70B weights2megatron OOM fix

### DIFF
--- a/tools/push_to_hub.py
+++ b/tools/push_to_hub.py
@@ -8,7 +8,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Push checkpoints in HF transformers format to the Huggingface Hub.",
-        epilog="Example usage: python push_to_hub.py /path/to/checkpoint --hf_repo_name myorg/model_name --dtype pf16 --auth_token hf_ba..."
+        epilog="Example usage: python push_to_hub.py /path/to/checkpoint --hf_repo_name your_org/model_name --dtype bf16 --auth_token hf_ba..."
     )
     parser.add_argument(
         "model_name",

--- a/weights2megatron/weights2megatron.py
+++ b/weights2megatron/weights2megatron.py
@@ -133,6 +133,14 @@ def llama_to_megatron(weights: dict, size: int, source: str = "meta",
             weights[f"{prefix}.attention.wk.weight"],
             weights[f"{prefix}.attention.wv.weight"]
         )
+
+        # free mem of original weights
+        del weights[f"{prefix}.feed_forward.w3.weight"]
+        del weights[f"{prefix}.feed_forward.w1.weight"]
+        del weights[f"{prefix}.attention.wq.weight"]
+        del weights[f"{prefix}.attention.wk.weight"]
+        del weights[f"{prefix}.attention.wv.weight"]
+
     return {"embedding": embedding, "transformer": transformer,
             "lm_head": lm_head}
 

--- a/weights2megatron/weights2megatron.py
+++ b/weights2megatron/weights2megatron.py
@@ -134,7 +134,7 @@ def llama_to_megatron(weights: dict, size: int, source: str = "meta",
             weights[f"{prefix}.attention.wv.weight"]
         )
 
-        # free mem of original weights
+        # release references to original weights (free mem)
         del weights[f"{prefix}.feed_forward.w3.weight"]
         del weights[f"{prefix}.feed_forward.w1.weight"]
         del weights[f"{prefix}.attention.wq.weight"]


### PR DESCRIPTION
- On nodes with 504GB RAM conversion of llama2 70b with weights2megatron.py failed due to OOM. By deleting/releasing the tensor references after the they have been duplicated by `torch.concat()` and `rearrange_qkv()` the excess mem usage can be mitigated.
- includes minor corrections of text
