### PR TITLE
Fix merge order in merge_meta_llama()

### DIFF
--- a/weights2megatron/merge_llama.py
+++ b/weights2megatron/merge_llama.py
@@ -58,8 +58,8 @@ def init_merged_ckpt(pth_00, num_pth=8, emb_dim=8192):
 
 
 def merge_meta_llama(size: int, root_dir: Path):
-    paths = [path for path in root_dir.iterdir()
-            if re.match(r"^consolidated\.[0-9]+\.pth$", path.name)]
+    paths = sorted(path for path in root_dir.iterdir()
+            if re.match(r"^consolidated\.[0-9]+\.pth$", path.name))
     if len(paths) == 1:  # no sharded checkpoints, return everything
         return torch.load(paths[0], map_location=torch.device("cpu"))
 


### PR DESCRIPTION
The function [merge_meta_llama()](https://github.com/epfLLM/Megatron-LLM/blob/0da33fd12a29a96d50b0f98572117053961a0046/weights2megatron/merge_llama.py#L60C5-L86) uses [Path.iterdir()](https://docs.python.org/3/library/pathlib.html#pathlib.Path.iterdir) to list the files of the llama2 weights input directory. `iterdir()` yields directory entries in arbitrary order. For larger llama2 models like 70B the weights consist of a number of shard files named `consolidated.{number}.pth`. This PR fixes the order in which the files are processed by sorting the returned directory listing.

Run from checkpoint without sorting: [run44_oasst_pre10_llama2_70b](https://wandb.ai/open-assistant/epfl-mt-sft/runs/run44_oasst_pre10_llama2_70b) lm loss starts at ~12 
Run from checkpoint with sorting: [run45_oasst_pre10_llama2_70](https://wandb.ai/open-assistant/epfl-mt-sft/runs/run45_oasst_pre10_llama2_70) lm loss starts at ~1