### PR TITLE
Set max_position_embeddings to args.seq_length in LlamaConfig

### DIFF
--- a/weights2megatron/megatron2hf.py
+++ b/weights2megatron/megatron2hf.py
@@ -187,6 +187,7 @@ def write_llama_model(model_path,
             num_hidden_layers=n_layers,
             rms_norm_eps=norm_eps,
             num_key_value_heads=n_heads_kv,
+            max_position_embeddings=args.seq_length,
         )
         config.save_pretrained(tmp_model_path)
 


### PR DESCRIPTION
LlamaConfig of HF transformers has a max_position_embedding default value of 2048 (see [configuration_llama.py#L115](https://github.com/huggingface/transformers/blob/1982dd3b15867c46e1c20645901b0de469fd935f/src/transformers/models/llama/configuration_llama.py#L115)), but Llama2 was trained on 4096 tokens.
This PR assigns the `args.seq_length` of the checkpoint to the llama configuration's `max_position_embeddings` field.