### PR TITLE
From custom hf source

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -141,6 +141,19 @@ torchrun \
 The file `examples/finetune.sh` gives the full picture of the arguments used to train either LLaMa.
 ```
 
+## How to convert a LLaMa or Falcon architecture from a non-official checkpoint?
+
+If you want to convert weights from a checkpoint other than the checkpoints provided by `llama-meta` or `tiiuae`, you might use `--model-path` during conversion.
+For instance, to convert the [OpenAssistant llama2 70B](https://huggingface.co/OpenAssistant/llama2-70b-oasst-sft-v10) weights, run:
+
+```
+python weights_conversion/hf_to_megatron.py llama2 --size=70 \
+	--out=/path/to/megatron/weights/ --cache-dir=/path/to/llama-2-7b/ \
+	--model-path=OpenAssistant/llama2-70b-oasst-sft-v10
+```
+
+The `--model-path` argument should be either a local folder or the name of a model hosted on huggingface.
+
 ## I'm getting a `17300 Bus error (core dumped)` error!
 
 If you are using a docker container and you get this error when sharding a large model, you might need to increase the shared memory size.

--- a/weights_conversion/hf_to_megatron.py
+++ b/weights_conversion/hf_to_megatron.py
@@ -272,13 +272,20 @@ def main(model_name: str = "falcon", size: int = 7, out: Optional[Path] = None,
     print("Saved weights in", out)
 
     if model_name in {"llama", "llama2"} and llama_source == "hf":
-        if model_name == "llama2":
-            name = "meta-llama/Llama-2-7b-hf"
-        else:
-            name = "decapoda-research/llama-7b-hf"
-        tokenizer = LlamaTokenizer.from_pretrained(
-            "meta-llama/Llama-2-7b-hf", cache_dir=cache_dir
-        )
+        tokenizer = None
+        if model_path is not None:
+            try:
+                tokenizer = LlamaTokenizer.from_pretrained(model_path, cache_dir=cache_dir)
+            except OSError:
+                warnings.warn(f"Model path {model_path} does not have a "
+                              "tokenizer, using default tokenizer instead")
+        if tokenizer is None:
+            if model_name == "llama2":
+                name = "meta-llama/Llama-2-7b-hf"
+            else:
+                name = "decapoda-research/llama-7b-hf"
+            tokenizer = LlamaTokenizer.from_pretrained(name, cache_dir=cache_dir)
+
         token_path = out/"tokenizer.model"
         vocab_file = tokenizer.vocab_file
         shutil.copy(vocab_file, token_path)


### PR DESCRIPTION
New feature:
- [x] When using `weights_conversion/hf_to_megatron.py` now you can specify the `--model-path` of the model you wish to convert. This means that if you don't want to use the official meta llama weights, but instead for instance [PMC LLaMa](https://huggingface.co/chaoyi-wu/PMC_LLAMA_7B) or [OpenAssistant LLaMa](https://huggingface.co/chaoyi-wu/PMC_LLAMA_7B), you might specify the `repo/name` of your desired weights. 