### PR TITLE
Use --no_new_tokens to stop adding built-in special tokens

### DIFF
--- a/megatron/tokenizer/tokenizer.py
+++ b/megatron/tokenizer/tokenizer.py
@@ -349,9 +349,9 @@ class _SentencePieceTokenizer(AbstractTokenizer):
             self._inv_vocab[i] = t
             self._vocab[t] = i
 
-        def _add_special_token(t):
-            # if t not in self.vocab and not new_tokens:
-            #     return
+        def _add_special_token(t, force=False):
+            if t not in self.vocab and not new_tokens and not force:
+                return
             if t not in self._vocab:
                 next_id = len(self._vocab)
                 self._vocab[t] = next_id
@@ -359,23 +359,22 @@ class _SentencePieceTokenizer(AbstractTokenizer):
             self._special_tokens[t] = self._vocab[t]
             self._inv_special_tokens[self._vocab[t]] = t
 
-        if new_tokens:
-            _add_special_token('<CLS>')
-            self._cls_id = self._vocab.get('<CLS>')
-            _add_special_token('<SEP>')
-            self._sep_id = self._vocab.get('<SEP>')
-            _add_special_token('<EOD>')
-            self._eod_id = self._vocab.get('<EOD>')
-            _add_special_token('<MASK>')
-            self._mask_id = self._vocab.get('<MASK>')
+        _add_special_token('<CLS>')
+        self._cls_id = self._vocab.get('<CLS>')
+        _add_special_token('<SEP>')
+        self._sep_id = self._vocab.get('<SEP>')
+        _add_special_token('<EOD>')
+        self._eod_id = self._vocab.get('<EOD>')
+        _add_special_token('<MASK>')
+        self._mask_id = self._vocab.get('<MASK>')
 
-            pad_id = self._tokenizer.pad_id()
-            try:
-                pad_token = self._tokenizer.id_to_piece(pad_id)
-            except IndexError:
-                pad_token = '<PAD>'
-            _add_special_token(pad_token)
-            self._pad_id = self._vocab.get(pad_token)
+        pad_id = self._tokenizer.pad_id()
+        try:
+            pad_token = self._tokenizer.id_to_piece(pad_id)
+        except IndexError:
+            pad_token = '<PAD>'
+        _add_special_token(pad_token)
+        self._pad_id = self._vocab.get(pad_token)
 
         bos_id = self._tokenizer.bos_id()
         try:
@@ -399,11 +398,11 @@ class _SentencePieceTokenizer(AbstractTokenizer):
 
         for i in range(vocab_extra_ids):
             t = "<extra_id_{}>".format(i)
-            _add_special_token(t)
+            _add_special_token(t, force=True)
             self._t5_tokens += [t]
         if vocab_extra_ids_list:
             for t in vocab_extra_ids_list.split(","):
-                _add_special_token(t)
+                _add_special_token(t, force=True)
         print("Special tokens: {}".format(self._special_tokens))
 
     @property

--- a/megatron/tokenizer/tokenizer.py
+++ b/megatron/tokenizer/tokenizer.py
@@ -350,8 +350,8 @@ class _SentencePieceTokenizer(AbstractTokenizer):
             self._vocab[t] = i
 
         def _add_special_token(t):
-            if t not in self.vocab and not new_tokens:
-                return
+            # if t not in self.vocab and not new_tokens:
+            #     return
             if t not in self._vocab:
                 next_id = len(self._vocab)
                 self._vocab[t] = next_id
@@ -359,22 +359,23 @@ class _SentencePieceTokenizer(AbstractTokenizer):
             self._special_tokens[t] = self._vocab[t]
             self._inv_special_tokens[self._vocab[t]] = t
 
-        _add_special_token('<CLS>')
-        self._cls_id = self._vocab.get('<CLS>')
-        _add_special_token('<SEP>')
-        self._sep_id = self._vocab.get('<SEP>')
-        _add_special_token('<EOD>')
-        self._eod_id = self._vocab.get('<EOD>')
-        _add_special_token('<MASK>')
-        self._mask_id = self._vocab.get('<MASK>')
+        if new_tokens:
+            _add_special_token('<CLS>')
+            self._cls_id = self._vocab.get('<CLS>')
+            _add_special_token('<SEP>')
+            self._sep_id = self._vocab.get('<SEP>')
+            _add_special_token('<EOD>')
+            self._eod_id = self._vocab.get('<EOD>')
+            _add_special_token('<MASK>')
+            self._mask_id = self._vocab.get('<MASK>')
 
-        pad_id = self._tokenizer.pad_id()
-        try:
-            pad_token = self._tokenizer.id_to_piece(pad_id)
-        except IndexError:
-            pad_token = '<PAD>'
-        _add_special_token(pad_token)
-        self._pad_id = self._vocab.get(pad_token)
+            pad_id = self._tokenizer.pad_id()
+            try:
+                pad_token = self._tokenizer.id_to_piece(pad_id)
+            except IndexError:
+                pad_token = '<PAD>'
+            _add_special_token(pad_token)
+            self._pad_id = self._vocab.get(pad_token)
 
         bos_id = self._tokenizer.bos_id()
         try:
@@ -391,6 +392,10 @@ class _SentencePieceTokenizer(AbstractTokenizer):
             eos_token = '<EOS>'
         _add_special_token(eos_token)
         self._eos_id = self._vocab.get(eos_token)
+
+        if not new_tokens:
+            # default to eos
+            self._pad_id = self._eos_id
 
         for i in range(vocab_extra_ids):
             t = "<extra_id_{}>".format(i)

--- a/weights_conversion/megatron_to_hf.py
+++ b/weights_conversion/megatron_to_hf.py
@@ -371,36 +371,34 @@ def write_tokenizer(args: Namespace):
     # add default args for megatron tokenizer
     args.rank = 0
     args.vocab_extra_ids = 0
-    args.new_tokens = True
     args.make_vocab_size_divisible_by = 128
     args.tensor_model_parallel_size = 1
     mt_tokenizer = build_tokenizer(args)
 
     if args.tokenizer_type == "SentencePieceTokenizer":
-        if mt_tokenizer.cls is not None:
-            hf_tokenizer.add_tokens("<CLS>", special_tokens=True)
-            hf_tokenizer.cls_token_id = mt_tokenizer.cls
-        if mt_tokenizer.sep is not None:
-            hf_tokenizer.add_tokens("<SEP>", special_tokens=True)
-            hf_tokenizer.sep_token_id = mt_tokenizer.sep
-        if mt_tokenizer.eod is not None:
-            hf_tokenizer.add_tokens("<EOD>", special_tokens=True)
-        if mt_tokenizer.mask is not None:
-            hf_tokenizer.add_tokens("<MASK>", special_tokens=True)
-            hf_tokenizer.mask_token_id = mt_tokenizer.mask
-        if mt_tokenizer.pad is not None:
-            hf_tokenizer.add_tokens("<PAD>", special_tokens=True)
-            hf_tokenizer.pad_token_id = mt_tokenizer.pad
+        # Do not add def special tokens if requested
+        if args.new_tokens:
+            if mt_tokenizer.cls is not None:
+                hf_tokenizer.add_tokens("<CLS>", special_tokens=True)
+                hf_tokenizer.cls_token_id = mt_tokenizer.cls
+            if mt_tokenizer.sep is not None:
+                hf_tokenizer.add_tokens("<SEP>", special_tokens=True)
+                hf_tokenizer.sep_token_id = mt_tokenizer.sep
+            if mt_tokenizer.eod is not None:
+                hf_tokenizer.add_tokens("<EOD>", special_tokens=True)
+            if mt_tokenizer.mask is not None:
+                hf_tokenizer.add_tokens("<MASK>", special_tokens=True)
+                hf_tokenizer.mask_token_id = mt_tokenizer.mask
+            if mt_tokenizer.pad is not None:
+                hf_tokenizer.add_tokens("<PAD>", special_tokens=True)
+                hf_tokenizer.pad_token_id = mt_tokenizer.pad
 
         additional_special_tokens = hf_tokenizer.additional_special_tokens
-        special_tokens = {"additional_special_tokens": additional_special_tokens}
         if args.vocab_extra_ids_list:
             additional_special_tokens.extend(args.vocab_extra_ids_list.split(","))
 
-        hf_tokenizer.add_special_tokens(special_tokens_dict=special_tokens, replace_additional_special_tokens=True)
-
-        additional_special_tokens_ids = [mt_tokenizer.vocab.get(t) for t in additional_special_tokens]
-        hf_tokenizer.additional_special_tokens_ids = additional_special_tokens_ids
+        for special_token in additional_special_tokens:
+            hf_tokenizer.add_special_tokens({"additional_special_tokens": [special_token]})
 
         hf_vocab = hf_tokenizer.get_vocab()
         tokens_to_check = [
@@ -453,6 +451,9 @@ def main():
                         help=("One or more arguments to override special tokens. "
                               "Syntax set as `key=value`, e.g. `eos=<|im_end|>`. "
                               "Overrides available only bos, cls, eos, mask, pad, sep, unk."))
+    parser.add_argument("--no_new_tokens", action="store_false", dest="new_tokens",
+                       help=("Do not add special tokens (e.g. CLS, MASK, etc) "
+                             "in the sentenciepiece tokenizer"))
     
     args = parser.parse_args()
     if args.model in {"llama", "llama2", "codellama"}:

--- a/weights_conversion/megatron_to_hf.py
+++ b/weights_conversion/megatron_to_hf.py
@@ -377,7 +377,6 @@ def write_tokenizer(args: Namespace):
     mt_tokenizer = build_tokenizer(args)
 
     if args.tokenizer_type == "SentencePieceTokenizer":
-        # Do not add def special tokens if requested
         if mt_tokenizer.cls is not None:
             hf_tokenizer.add_tokens("<CLS>", special_tokens=True)
             hf_tokenizer.cls_token_id = mt_tokenizer.cls

--- a/weights_conversion/megatron_to_hf.py
+++ b/weights_conversion/megatron_to_hf.py
@@ -371,27 +371,27 @@ def write_tokenizer(args: Namespace):
     # add default args for megatron tokenizer
     args.rank = 0
     args.vocab_extra_ids = 0
+    args.new_tokens = True
     args.make_vocab_size_divisible_by = 128
     args.tensor_model_parallel_size = 1
     mt_tokenizer = build_tokenizer(args)
 
     if args.tokenizer_type == "SentencePieceTokenizer":
         # Do not add def special tokens if requested
-        if args.new_tokens:
-            if mt_tokenizer.cls is not None:
-                hf_tokenizer.add_tokens("<CLS>", special_tokens=True)
-                hf_tokenizer.cls_token_id = mt_tokenizer.cls
-            if mt_tokenizer.sep is not None:
-                hf_tokenizer.add_tokens("<SEP>", special_tokens=True)
-                hf_tokenizer.sep_token_id = mt_tokenizer.sep
-            if mt_tokenizer.eod is not None:
-                hf_tokenizer.add_tokens("<EOD>", special_tokens=True)
-            if mt_tokenizer.mask is not None:
-                hf_tokenizer.add_tokens("<MASK>", special_tokens=True)
-                hf_tokenizer.mask_token_id = mt_tokenizer.mask
-            if mt_tokenizer.pad is not None:
-                hf_tokenizer.add_tokens("<PAD>", special_tokens=True)
-                hf_tokenizer.pad_token_id = mt_tokenizer.pad
+        if mt_tokenizer.cls is not None:
+            hf_tokenizer.add_tokens("<CLS>", special_tokens=True)
+            hf_tokenizer.cls_token_id = mt_tokenizer.cls
+        if mt_tokenizer.sep is not None:
+            hf_tokenizer.add_tokens("<SEP>", special_tokens=True)
+            hf_tokenizer.sep_token_id = mt_tokenizer.sep
+        if mt_tokenizer.eod is not None:
+            hf_tokenizer.add_tokens("<EOD>", special_tokens=True)
+        if mt_tokenizer.mask is not None:
+            hf_tokenizer.add_tokens("<MASK>", special_tokens=True)
+            hf_tokenizer.mask_token_id = mt_tokenizer.mask
+        if mt_tokenizer.pad is not None:
+            hf_tokenizer.add_tokens("<PAD>", special_tokens=True)
+            hf_tokenizer.pad_token_id = mt_tokenizer.pad
 
         additional_special_tokens = hf_tokenizer.additional_special_tokens
         if args.vocab_extra_ids_list:
@@ -451,9 +451,6 @@ def main():
                         help=("One or more arguments to override special tokens. "
                               "Syntax set as `key=value`, e.g. `eos=<|im_end|>`. "
                               "Overrides available only bos, cls, eos, mask, pad, sep, unk."))
-    parser.add_argument("--no_new_tokens", action="store_false", dest="new_tokens",
-                       help=("Do not add special tokens (e.g. CLS, MASK, etc) "
-                             "in the sentenciepiece tokenizer"))
     
     args = parser.parse_args()
     if args.model in {"llama", "llama2", "codellama"}:


### PR DESCRIPTION
- Support to use `--no_new_tokens` to ignore adding built-in special tokens (`<CLS>, <SEP>, <EOD>, <MASK>`) which might not be necessary (_Originally posted by @andreaskoepf in https://github.com/epfLLM/Megatron-LLM/issues/19#issuecomment-1677015358_).

- Fix new token ordering issue of the `weights_conversion/megatron_to_hf.py` conversion script: When set `--vocab_extra_ids_list "<|im_start|>,<|im_end|>"`, the `hf_tokenizer.add_special_tokens(special_tokens_dict=special_tokens, replace_additional_special_tokens=True)` will cause the extra ids to be added with a different order to the `hf_tokenizer` since the [hf tokenizer implementation](https://github.com/huggingface/transformers/blob/32f799db0d625ec5cf82624ff2604c5a891ebf61/src/transformers/tokenization_utils_base.py#L946) will convert the ["<im_start>", "<im_end>"] to a set before adding them to the special token which can mess-up the order (Megatron LLM seem to add these special tokens following the list order).
