### PR TITLE
Support specifying load_iters for checkpoint

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -770,6 +770,10 @@ def _add_checkpointing_args(parser):
                        help='Do not save current rng state.')
     group.add_argument('--load', type=str, default=None,
                        help='Directory containing a model checkpoint.')
+    group.add_argument('--load_iters', type=int, default=None,
+                       help='Specify which checkpoint to load. If not '
+                          'specified, the latest checkpoint (highest iteration '
+                            'number) located in the load directory will be used.')
     group.add_argument('--no_load_optim', action='store_true', default=None,
                        help='Do not load optimizer when loading checkpoint.')
     group.add_argument('--no_load_rng', action='store_true', default=None,

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -431,7 +431,6 @@ def _load_base_checkpoint(load_dir, use_distributed_optimizer, rank0=False, spec
     # Otherwise, read the tracker file and either set the iteration or
     # mark it as a release checkpoint.
     iteration, release = read_metadata(tracker_filename)
-    print_rank_0(f"specify_iteration {specify_iteration}")
     if specify_iteration is not None:
         print_rank_0(
             f'overriding iteration {iteration} read from checkpoint with specified iteration {specify_iteration}'

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -437,7 +437,7 @@ def _load_base_checkpoint(load_dir, use_distributed_optimizer, rank0=False, spec
             f'overriding iteration {iteration} read from checkpoint with specified iteration {specify_iteration}'
         )
         iteration = specify_iteration
-        release = False
+        release = iteration == 0
 
     # Checkpoint.
     if rank0:

--- a/tools/checkpoint_loader_megatron.py
+++ b/tools/checkpoint_loader_megatron.py
@@ -58,6 +58,10 @@ def _load_checkpoint(queue, args):
         sys.argv += ["--bf16"]
 
     margs = megatron.arguments.parse_args()
+
+    if args.load_iters is not None:
+        margs.load_iters = args.load_iters
+
     margs = load_args_from_checkpoint(margs)
 
     # Arguments do sanity checks on the world size, but we don't care,

--- a/tools/checkpoint_loader_megatron.py
+++ b/tools/checkpoint_loader_megatron.py
@@ -56,8 +56,8 @@ def _load_checkpoint(queue, args):
 
     if args.bf16:
         sys.argv += ["--bf16"]
-    if args.load_iteration is not None:
-        sys.argv += ["--load_iters", args.load_iters]
+    if args.load_iters is not None:
+        sys.argv += ["--load_iters", str(args.load_iters)]
 
     margs = megatron.arguments.parse_args()
     margs = load_args_from_checkpoint(margs)

--- a/tools/checkpoint_loader_megatron.py
+++ b/tools/checkpoint_loader_megatron.py
@@ -56,12 +56,10 @@ def _load_checkpoint(queue, args):
 
     if args.bf16:
         sys.argv += ["--bf16"]
+    if args.load_iteration is not None:
+        sys.argv += ["--load_iters", args.load_iters]
 
     margs = megatron.arguments.parse_args()
-
-    if args.load_iters is not None:
-        margs.load_iters = args.load_iters
-
     margs = load_args_from_checkpoint(margs)
 
     # Arguments do sanity checks on the world size, but we don't care,

--- a/tools/checkpoint_util.py
+++ b/tools/checkpoint_util.py
@@ -125,6 +125,10 @@ def main():
                         help='Do not perform checking on the name and ordering of weights',
                         dest='checking')
     parser.add_argument('--bf16', action='store_true', help='force bfloat16 weights')
+    parser.add_argument('--load_iters', type=int, default=None,
+                    help='Specify which checkpoint to load. If not '
+                        'specified, the latest checkpoint (highest iteration '
+                        'number) located in the load directory will be used.')
 
     known_args, _ = parser.parse_known_args()
     loader = load_plugin('loader', known_args.loader)


### PR DESCRIPTION
Support converting a sharded checkpoint with a specified iteration back to unshared version.

For example, you can set $LOAD_ITER to 52 to load the checkpoint of 52nd iteration `$LOAD_DIR/iter_0000052`. This will override the read iteration number from the tracker file.

```bash
python Megatron-LLM/tools/checkpoint_util.py \
	--target_tensor_parallel_size 1 \
	--target_pipeline_parallel_size 1 \
	--load_dir $LOAD_DIR \
	--load_iters $LOAD_ITER \
	--save_dir $OUTPUT_DIR \
	--model_type llama2 \
	--true_vocab_size $VOCAB_SIZE \
	--bf16
```

