### PR TITLE
Add Mistral Model

### DIFF
--- a/finetune.py
+++ b/finetune.py
@@ -37,6 +37,9 @@ def model_provider(pre_process: bool = True, post_process: bool = True):
         cls = partial(LlamaModel, version=1 if args.model_name == "llama" else 2)
     elif args.model_name == "mistral":
         cls = MistralModel
+        if args.sliding_window_size != 4096:
+            print_rank_0("Mistral uses sliding window attention (set sliding_window=4096)")
+            args.sliding_window_size = 4096
     else:
         raise KeyError(f"Unkown model {args.model_name}")
 

--- a/finetune.py
+++ b/finetune.py
@@ -9,7 +9,7 @@ from megatron import get_args, get_tokenizer, get_timers, get_counters, print_ra
 from megatron.training import pretrain
 from megatron.core import tensor_parallel
 from megatron.core.parallel_state import get_data_parallel_group
-from megatron.model import GPTModel, ModelType, LlamaModel, FalconModel
+from megatron.model import GPTModel, ModelType, LlamaModel, FalconModel, MistralModel
 from megatron.utils import get_ltor_masks_and_position_ids, average_losses_across_data_parallel_group
 from megatron.data.gpt_dataset import build_train_valid_test_datasets as gpt_build_datasets
 from megatron.data.instruction_dataset import instruction_collator
@@ -35,8 +35,10 @@ def model_provider(pre_process: bool = True, post_process: bool = True):
         cls = FalconModel
     elif args.model_name in {"llama", "llama2", "codellama"}:
         cls = partial(LlamaModel, version=1 if args.model_name == "llama" else 2)
+    elif args.model_name == "mistral":
+        cls = MistralModel
     else:
-        raise KeyError(f"Unkown model {other}")
+        raise KeyError(f"Unkown model {args.model_name}")
 
     if isinstance(args.model_type, ModelType):
         model_type = args.model_type
@@ -238,7 +240,7 @@ def extra_args(parser):
     """Text generation arguments."""
     group = parser.add_argument_group(title='validation set')
     group.add_argument("--model_name",
-                       choices={"gpt", "llama", "falcon", "llama2", "codellama"},
+                       choices={"gpt", "llama", "falcon", "llama2", "codellama", "mistral"},
                        default="gpt")
     group.add_argument("--model_type", choices={"encoder_or_decoder", "encoder_and_decoder"},
                        default="encoder_or_decoder")

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -476,8 +476,8 @@ def _add_network_size_args(parser):
                        help=("If set, the weights of the word embedding and lm_head "
                              "are not tied"))
     # Added for Mistral
-    group.add_argument("--sliding_window", type=int, default=None,
-                       help="Whether to use sliding window attention for Mistral")
+    group.add_argument("--sliding_window_size", type=int, default=None,
+                       help="Whether to use sliding window attention for Mistral. Default is None, which means no sliding window attention.")
     return parser
 
 

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -475,6 +475,9 @@ def _add_network_size_args(parser):
     group.add_argument("--no_tie_embed_logits", action="store_false", dest="tie_embed_logits",
                        help=("If set, the weights of the word embedding and lm_head "
                              "are not tied"))
+    # Added for Mistral
+    group.add_argument("--sliding_window", type=int, default=None,
+                       help="Whether to use sliding window attention for Mistral")
     return parser
 
 

--- a/megatron/checkpointing.py
+++ b/megatron/checkpointing.py
@@ -549,6 +549,7 @@ def load_args_from_checkpoint(args, load_arg='load'):
     _set_arg('tie_embed_logits', force=True)
     _set_arg('make_vocab_size_divisible_by', force=True)
     _set_arg('train_iters')
+    _set_arg('sliding_window_size')
     if checkpoint_version < 3.0:
         _set_arg('tensor_model_parallel_size',
                  'model_parallel_size')

--- a/megatron/model/__init__.py
+++ b/megatron/model/__init__.py
@@ -8,6 +8,7 @@ from .bert_model import BertModel
 from .gpt_model import GPTModel
 from .llama_model import LlamaModel
 from .falcon_model import FalconModel
+from .mistral_model import MistralModel
 from .t5_model import T5Model
 from .module import Float16Module
 from .enums import ModelType

--- a/megatron/model/mistral_model.py
+++ b/megatron/model/mistral_model.py
@@ -27,7 +27,7 @@ class MistralModel(GPTModel):
         assert not args.parallel_attn, "Mistral does not use parallel_attn"
         assert args.use_rms_norm, "Mistral uses rms_norm"
         assert not args.tie_embed_logits , "Mistral unties embedding and lm_head weights"
-        assert args.sliding_window == 4096, "Mistral uses sliding window attention (sliding_window=4096)"
+        assert args.sliding_window_size == 4096, "Mistral uses sliding window attention (sliding_window=4096)"
 
         # recomended arguments
         if not args.use_flash_attn:

--- a/megatron/model/mistral_model.py
+++ b/megatron/model/mistral_model.py
@@ -1,0 +1,46 @@
+"""Mistral Model."""
+
+import warnings
+
+from megatron import get_args
+from .enums import PositionEmbeddingType
+from . import GPTModel
+
+
+class MistralModel(GPTModel):
+    def __init__(self,
+                 num_tokentypes: int = 0,
+                 parallel_output: bool = True,
+                 pre_process: bool = True,
+                 post_process: bool = True,
+                 model_type=None
+                 ):
+
+        args = get_args()
+
+        # mandatory arguments
+        assert args.position_embedding_type == PositionEmbeddingType.rotary, \
+            f"Mistral uses rotary embedding, not {args.position_embedding_type}"
+        assert not args.use_post_ln, "Mistral does not use post_ln"
+        assert args.glu_activation == "swiglu", "Mistral works with swiglu activation"
+        assert not args.use_bias, "Mistral does not use bias"
+        assert not args.parallel_attn, "Mistral does not use parallel_attn"
+        assert args.use_rms_norm, "Mistral uses rms_norm"
+        assert not args.tie_embed_logits , "Mistral unties embedding and lm_head weights"
+        assert args.sliding_window == 4096, "Mistral uses sliding window attention (sliding_window=4096)"
+
+        # recomended arguments
+        if not args.use_flash_attn:
+            warnings.warn("Mistral should use flash attn (for sliding window local attention)")
+
+        if args.bias_gelu_fusion:
+            warnings.warn("Mistral is not intended to use bias_gelu_fusion")
+        if args.bias_dropout_fusion:
+            warnings.warn("Mistral is not intended to use bias_dropout_fusion")
+        if args.hidden_dropout > 0.0 and not args.lima_dropout:
+            warnings.warn("Mistral is not intended to use dropout")
+        if args.attention_dropout > 0.0:
+            warnings.warn("Mistral is not intended to use dropout")
+        super().__init__(num_tokentypes=num_tokentypes, parallel_output=parallel_output,
+                         pre_process=pre_process, post_process=post_process,
+                         model_type=model_type)

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -305,7 +305,6 @@ class ParallelAttention(MegatronModule):
         self.num_attention_heads_kv = args.num_attention_heads_kv
         self.num_attention_heads = args.num_attention_heads
         self.seq_length = args.seq_length
-        self.packed_input = args.packed_input
         if self.use_flash_attn:
             assert attention_type == AttnType.self_attn, ('FlashAttention code path only supports '
                                                           'self-attention for now')

--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -23,7 +23,7 @@ from megatron.model.utils import attention_mask_func, erf_gelu
 # Extracted from: https://github.com/bigscience-workshop/Megatron-DeepSpeed
 from .glu_activations import GLU_ACTIVATIONS
 from megatron.model.positional_embeddings import precompute_freqs_cis, apply_rotary_emb
-
+from flash_attn.bert_padding import pad_input, unpad_input_for_concatenated_sequences
 
 """ We use the following notation throughout this file:
      h: hidden size
@@ -301,14 +301,24 @@ class ParallelAttention(MegatronModule):
         self.params_dtype = args.params_dtype
         self.sequence_parallel = args.sequence_parallel
         self.use_flash_attn = args.use_flash_attn
+        self.sliding_window_size = args.sliding_window_size
         self.num_attention_heads_kv = args.num_attention_heads_kv
         self.num_attention_heads = args.num_attention_heads
         self.seq_length = args.seq_length
+        self.packed_input = args.packed_input
         if self.use_flash_attn:
             assert attention_type == AttnType.self_attn, ('FlashAttention code path only supports '
                                                           'self-attention for now')
             assert self.attn_mask_type == AttnMaskType.causal, ('FlashAttention code path only '
                                                                 'supports causal mask for now')
+            # If sliding window is enabled, we need to make sure that the sliding window is supported.
+            if self.sliding_window_size is not None:
+                import inspect
+                # https://github.com/huggingface/transformers/blob/7e1eff7600085814eac65876d4d8a0e38c2f6ccc/src/transformers/models/mistral/modeling_mistral.py#L50C5-L50C32
+                assert "window_size" in list(inspect.signature(
+                    flash_attn.flash_attn_func
+                ).parameters), "The current flash attention version does not support sliding window attention, please update to the latest version."
+                assert self.use_flash_attn, "Sliding window attention is only supported with flash attention for now."
 
         projection_size = args.kv_channels * args.num_attention_heads
 
@@ -513,13 +523,34 @@ class ParallelAttention(MegatronModule):
                 context_layer = self.core_attention(
                     query_layer, key_layer, value_layer, attention_mask)
         else:
+            flash_attn_extra_kwargs = {}
+            # check if we need to use sliding window attention
+            # https://github.com/huggingface/transformers/blob/7ee995fd9c692761c4601ddbffa2ac2ec9f27b0b/src/transformers/models/mistral/modeling_mistral.py#L353
+            if self.sliding_window_size is not None:
+                kv_seq_len = key_layer.shape[0]
+                if kv_seq_len > self.sliding_window_size:
+                    # https://github.com/huggingface/transformers/blob/7ee995fd9c692761c4601ddbffa2ac2ec9f27b0b/src/transformers/models/mistral/modeling_mistral.py#L510C21-L510C89
+                    flash_attn_extra_kwargs["window_size"] = (
+                        self.sliding_window_size, self.sliding_window_size
+                    )
+                    # It will be truncated to the actual sequence length inside flash attention
+                    # https://github.com/Dao-AILab/flash-attention/blob/83aef842beec1037eb8c1d9c3ef3ed8aae80b091/csrc/flash_attn/src/softmax.h#L159-L161
+
             q, k, v = [rearrange(x, "s b n h -> b s n h").contiguous()
-                       for x in (query_layer, key_layer, value_layer)]
+                    for x in (query_layer, key_layer, value_layer)]
             if not self.sequence_parallel:
                 with megatron.core.tensor_parallel.get_cuda_rng_tracker().fork():
-                    context_layer = self.core_attention_flash(q, k, v, causal=True)
+                    context_layer = self.core_attention_flash(
+                        q, k, v,
+                        causal=True,
+                        **flash_attn_extra_kwargs
+                    )
             else:
-                context_layer = self.core_attention_flash(q, k, v, causal=True)
+                context_layer = self.core_attention_flash(
+                    q, k, v,
+                    causal=True,
+                    **flash_attn_extra_kwargs
+                )
             context_layer = rearrange(context_layer, 'b s n h -> s b (n h)').contiguous()
 
         # =================

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 transformers >= 4.31.0
 torch >= 2.0.0
-flash-attn >= 2.0.0
+flash-attn >= 2.3.3
 datasets >= 2.14.0
 nltk >= 3.8.0
 sentencepiece >= 0.1.0

--- a/tools/checkpoint_loader_megatron.py
+++ b/tools/checkpoint_loader_megatron.py
@@ -90,7 +90,7 @@ def _load_checkpoint(queue, args):
     if args.model_type == 'GPT':
         from pretrain_gpt import model_provider
         margs.model_type = ModelType.encoder_or_decoder
-    elif args.model_type in {"falcon", "llama", "llama2", "codellama"}:
+    elif args.model_type in {"falcon", "llama", "llama2", "codellama", "mistral"}:
         from finetune import model_provider
         margs.model_name = args.model_type
         margs.model_type = ModelType.encoder_or_decoder

--- a/tools/checkpoint_loader_megatron.py
+++ b/tools/checkpoint_loader_megatron.py
@@ -185,6 +185,8 @@ def _load_checkpoint(queue, args):
     md.glu_activation = margs.glu_activation
     md.tie_embed_logits = margs.tie_embed_logits
     md.params_dtype = margs.params_dtype
+    if hasattr(margs, "sliding_window_size"):
+        md.sliding_window_size = margs.sliding_window_size
     if margs.position_embedding_type == PositionEmbeddingType.absolute:
         md.position_embedding_type = "absolute"
     elif margs.position_embedding_type == PositionEmbeddingType.rotary:

--- a/tools/checkpoint_loader_megatron.py
+++ b/tools/checkpoint_loader_megatron.py
@@ -185,8 +185,7 @@ def _load_checkpoint(queue, args):
     md.glu_activation = margs.glu_activation
     md.tie_embed_logits = margs.tie_embed_logits
     md.params_dtype = margs.params_dtype
-    if hasattr(margs, "sliding_window_size"):
-        md.sliding_window_size = margs.sliding_window_size
+    md.sliding_window_size = margs.sliding_window_size
     if margs.position_embedding_type == PositionEmbeddingType.absolute:
         md.position_embedding_type = "absolute"
     elif margs.position_embedding_type == PositionEmbeddingType.rotary:

--- a/tools/checkpoint_saver_megatron.py
+++ b/tools/checkpoint_saver_megatron.py
@@ -154,7 +154,7 @@ def save_checkpoint(queue, args):
     elif md.model_type == 'BERT':
         from pretrain_bert import model_provider
         margs.model_type = ModelType.encoder_or_decoder
-    elif md.model_type in {'falcon', 'llama', 'llama2', 'codellama'}:
+    elif md.model_type in {'falcon', 'llama', 'llama2', 'codellama', 'mistral'}:
         from finetune import model_provider
         margs.model_name = args.model_type
         margs.model_type = ModelType.encoder_or_decoder

--- a/tools/checkpoint_util.py
+++ b/tools/checkpoint_util.py
@@ -109,7 +109,7 @@ def main():
                                      allow_abbrev=False, conflict_handler='resolve')
 
     parser.add_argument('--model_type', type=str, required=True,
-                        choices=['GPT', 'BERT', 'falcon', 'llama', 'llama2', 'codellama'],
+                        choices=['GPT', 'BERT', 'falcon', 'llama', 'llama2', 'codellama', 'mistral'],
                         help='Type of the model')
     parser.add_argument('--loader', type=str, default='megatron',
                         help='Module name to load checkpoint, should be on python path')


### PR DESCRIPTION
https://github.com/epfLLM/Megatron-LLM/issues/76#issue-1947436642

A preliminary Mistral Implementation which relies on FlashAttention for windowed attention.

Script for model conversion: 
```bash
#!/bin/bash

# download from huggingface: https://huggingface.co/mistralai/Mistral-7B-v0.1
RAW_MODEL_WEIGHT_DIR=/models/Mistral-7B-v0.1/
OUTPUT_DIR=data/models/raw/Mistral-7b-megatron

python Megatron-LLM/weights_conversion/hf_to_megatron.py mistral \
    --size=7 \
    --out=$OUTPUT_DIR \
    --model-path=$RAW_MODEL_WEIGHT_DIR \
```


Script for `verify_correctness`: 

```bash
# arguments required by `torchrun`
DISTRIBUTED_ARGS="--nproc_per_node 1 --nnodes 1 --node_rank 0 --master_addr localhost --master_port 8000"
MISTRAL_ARGS="--use_rms_norm --glu_activation swiglu --no_tie_embed_logits --no_new_tokens --layernorm_epsilon 1e-5 --use_flash_attn --bf16 --seq_length 512"
COMMON_ARGS="--hidden_dropout 0.0 --attention_dropout 0.0 --no_bias_gelu_fusion --no_bias_dropout_fusion"

HF_MODEL_DIR=/models/Mistral-7B-v0.1
MODEL_CKPT=data/models/raw/Mistral-7b-megatron
TOKENIZER_PATH=data/models/raw/Mistral-7b-megatron/tokenizer.model
DATA_PATH=data/megatron_format/starcoder_example/data_text_document

torchrun $DISTRIBUTED_ARGS Megatron-LLM/verify_correctness.py \
	--model_name=mistral \
	--model_size=7 \
	--load=$MODEL_CKPT \
	--data_path=$DATA_PATH \
	--tokenizer_type=SentencePieceTokenizer \
	--vocab_file=$TOKENIZER_PATH \
	--huggingface_cache=$HF_MODEL_DIR \
	--huggingface_device=cuda:1 \
	$COMMON_ARGS $MISTRAL_ARGS
```
The `starcoder_example` dataset can be prepared following the [quickstart guide](https://github.com/epfLLM/Megatron-LLM/blob/main/docs/guide/getting_started.md#preparing-the-raw-data).

Results (average loss diff is below 0.1 for `bf16`).
```
Iteration 0...
Max absoulute error in the logits: max=0.928502, avg=0.024152
Abs loss error: 0.000518 Our loss: 0.919, theirs: 0.919
Iteration 1...
Max absoulute error in the logits: max=1.135055, avg=0.017372
Abs loss error: 0.000350 Our loss: 1.351, theirs: 1.352
Iteration 2...
Max absoulute error in the logits: max=0.439639, avg=0.016328
Abs loss error: 0.001454 Our loss: 0.596, theirs: 0.598
Iteration 3...
Max absoulute error in the logits: max=1.323759, avg=0.016411
Abs loss error: 0.004381 Our loss: 1.550, theirs: 1.554
Iteration 4...
Max absoulute error in the logits: max=0.709203, avg=0.016201
Abs loss error: 0.002717 Our loss: 1.754, theirs: 1.757
Iteration 5...
Max absoulute error in the logits: max=0.776079, avg=0.017546
Abs loss error: 0.001265 Our loss: 1.462, theirs: 1.463
Iteration 6...
Max absoulute error in the logits: max=0.925026, avg=0.015901
Abs loss error: 0.002268 Our loss: 1.208, theirs: 1.211
Iteration 7...
Max absoulute error in the logits: max=1.482982, avg=0.018049
Abs loss error: 0.001490 Our loss: 1.300, theirs: 1.302
Iteration 8...
Max absoulute error in the logits: max=2.211723, avg=0.019359
Abs loss error: 0.001245 Our loss: 0.623, theirs: 0.625
Iteration 9...
Max absoulute error in the logits: max=2.620514, avg=0.017941
Abs loss error: 0.001800 Our loss: 0.899, theirs: 0.897
```